### PR TITLE
Make field specification optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ var json = [
   }
 ];
 
-deepjson2csv({data: json, fields: ['car', 'price', 'color']}, function(err, csv) {
+deepjson2csv({data: json}, function(err, csv) {
   if (err) console.log(err);
   fs.writeFile('file.csv', csv, function(err) {
     if (err) throw err;
@@ -160,8 +160,8 @@ Options:
   -d, --delimiter [delim] Specify a delimiter other than the default comma to use.
   -p, --pretty            Use only when printing to console. Logs output in pretty tables.
 ```
-      
-An input file `-i` and fields `-f` are required. If no output `-o` is specified the result is logged to the console.
+
+An input file `-i` is required. If no fields (`-f`) are specified, the default is to use all the keys of the first object. If no output `-o` is specified the result is logged to the console.
 Use `-p` to show the result in a beautiful table inside the console.
       
 ### CLI examples

--- a/lib/deepjson2csv.js
+++ b/lib/deepjson2csv.js
@@ -55,6 +55,9 @@ var checkParams = function(params, callback) {
     params.data = ar;
   }
 
+  // if no fields are specified, default to all keys of the first object
+  params.fields = params.fields || Object.keys(params.data[0])
+
   //#check fieldNames
   if (params.fieldNames && params.fieldNames.length !== params.fields.length) {
     callback(new Error('fieldNames and fields should be of the same length, if fieldNames is provided.'));


### PR DESCRIPTION
With the fields option omitted, default to the keys of the first object specified (all fields).

make test and npm run-script format both looked good, let me know if you'd like anything else
